### PR TITLE
Add support for "long" coordinate types.:wq

### DIFF
--- a/include/boost/polygon/isotropy.hpp
+++ b/include/boost/polygon/isotropy.hpp
@@ -137,7 +137,7 @@ namespace boost { namespace polygon{
   template <typename T1, typename T2>
   view_of<T1, T2> view_as(const T2& obj) { return view_of<T1, T2>(obj); }
 
-  template <typename T>
+  template <typename T, bool /*enable*/ = true>
   struct coordinate_traits {};
 
   //used to override long double with an infinite precision datatype
@@ -175,6 +175,17 @@ namespace boost { namespace polygon{
     typedef long double coordinate_distance;
   };
 
+  template<>
+  struct coordinate_traits<long, sizeof(long) == sizeof(int)> {
+    typedef coordinate_traits<int> cT_;
+    typedef cT_::coordinate_type coordinate_type;
+    typedef cT_::area_type area_type;
+    typedef cT_::manhattan_area_type manhattan_area_type;
+    typedef cT_::unsigned_area_type unsigned_area_type;
+    typedef cT_::coordinate_difference coordinate_difference;
+    typedef cT_::coordinate_distance coordinate_distance;
+  };
+
 #ifdef BOOST_POLYGON_USE_LONG_LONG
   template <>
   struct coordinate_traits<polygon_long_long_type> {
@@ -184,6 +195,17 @@ namespace boost { namespace polygon{
     typedef polygon_ulong_long_type unsigned_area_type;
     typedef polygon_long_long_type coordinate_difference;
     typedef long double coordinate_distance;
+  };
+
+  template<>
+  struct coordinate_traits<long, sizeof(long) == sizeof(polygon_long_long_type)> {
+    typedef coordinate_traits<polygon_long_long_type> cT_;
+    typedef cT_::coordinate_type coordinate_type;
+    typedef cT_::area_type area_type;
+    typedef cT_::manhattan_area_type manhattan_area_type;
+    typedef cT_::unsigned_area_type unsigned_area_type;
+    typedef cT_::coordinate_difference coordinate_difference;
+    typedef cT_::coordinate_distance coordinate_distance;
   };
 #endif
 


### PR DESCRIPTION
Hi. I discovered that the following code does not compile:

#include <boost/polygon/isotropy.hpp>
...
typedef boost::polygon::coordinate_traits<long>::area_type A;

I found this because I really want my coordinates to be 64 bits exactly, so I am using "int64_t", which on x86_64 is a typedef for "long". (On 32-bit it is a typedef for "long long".)

I believe this pull request covers the vast majority of cases without breaking anything, but I have only actually tested on 32-bit and 64-bit x86.