### PR TITLE
Use copy_construct() instead of two set() call for rectangle assign()

### DIFF
--- a/include/boost/polygon/rectangle_concept.hpp
+++ b/include/boost/polygon/rectangle_concept.hpp
@@ -190,8 +190,7 @@ namespace boost { namespace polygon{
       typename is_rectangle_concept<typename geometry_concept<rectangle_type_2>::type>::type>::type,
     rectangle_type_1>::type &
   assign(rectangle_type_1& lvalue, const rectangle_type_2& rvalue) {
-    set(lvalue, HORIZONTAL, get(rvalue, HORIZONTAL));
-    set(lvalue, VERTICAL, get(rvalue, VERTICAL));
+    lvalue = copy_construct<rectangle_type_1>(rvalue);
     return lvalue;
   }
 


### PR DESCRIPTION
This produces significantly better code when the rectangle representation is an immutable pair of points (lower left / upper right); e.g. SSE vectors. And there is no cost in speed for the normal case, since modern compilers are very good at copy elision.