### PR TITLE
Replace deprecated/removed C++98 function adapters by inlined typedefs.

### DIFF
--- a/include/boost/polygon/detail/boolean_op_45.hpp
+++ b/include/boost/polygon/detail/boolean_op_45.hpp
@@ -150,8 +150,11 @@ namespace boost { namespace polygon{
     //       return o;
     //     }
 
-    class lessScan45ElementRise : public std::binary_function<Scan45Element, Scan45Element, bool> {
+    class lessScan45ElementRise {
     public:
+      typedef Scan45Element first_argument_type;
+      typedef Scan45Element second_argument_type;
+      typedef bool result_type;
       inline lessScan45ElementRise() {} //default constructor is only constructor
       inline bool operator () (Scan45Element elm1, Scan45Element elm2) const {
         return elm1.rise < elm2.rise;
@@ -457,8 +460,11 @@ namespace boost { namespace polygon{
         return Scan45Element(vertex.first.x(), vertex.first.y(), index - 1, vertex.second[index]);
       }
 
-      class lessScan45Point : public std::binary_function<Point, Point, bool> {
+      class lessScan45Point {
       public:
+      typedef Point first_argument_type;
+      typedef Point second_argument_type;
+      typedef bool result_type;
         inline lessScan45Point() {} //default constructor is only constructor
         inline bool operator () (const Point& v1, const Point& v2) const {
           return (v1.x() < v2.x()) || (v1.x() == v2.x() && v1.y() < v2.y());

--- a/include/boost/polygon/detail/max_cover.hpp
+++ b/include/boost/polygon/detail/max_cover.hpp
@@ -36,8 +36,11 @@ namespace boost { namespace polygon{
 
     typedef std::pair<std::pair<Unit, Interval>, Node* > EdgeAssociation;
 
-    class lessEdgeAssociation : public std::binary_function<const EdgeAssociation&, const EdgeAssociation&, bool> {
+    class lessEdgeAssociation {
     public:
+      typedef const EdgeAssociation& first_argument_type;
+      typedef const EdgeAssociation& second_argument_type;
+      typedef bool result_type;
       inline lessEdgeAssociation() {}
       inline bool operator () (const EdgeAssociation& elem1, const EdgeAssociation& elem2) const {
         if(elem1.first.first < elem2.first.first) return true;

--- a/include/boost/polygon/detail/polygon_arbitrary_formation.hpp
+++ b/include/boost/polygon/detail/polygon_arbitrary_formation.hpp
@@ -22,8 +22,11 @@ namespace boost { namespace polygon{
     typedef point_data<Unit> Point;
     typedef std::pair<Point, Point> half_edge;
 
-    class less_point : public std::binary_function<Point, Point, bool> {
+    class less_point {
     public:
+      typedef Point first_argument_type;
+      typedef Point second_argument_type;
+      typedef bool result_type;
       inline less_point() {}
       inline bool operator () (const Point& pt1, const Point& pt2) const {
         if(pt1.get(HORIZONTAL) < pt2.get(HORIZONTAL)) return true;
@@ -264,12 +267,15 @@ namespace boost { namespace polygon{
     }
 
     //scanline comparator functor
-    class less_half_edge : public std::binary_function<half_edge, half_edge, bool> {
+    class less_half_edge {
     private:
       Unit *x_; //x value at which to apply comparison
       int *justBefore_;
       evalAtXforYPack * pack_;
     public:
+      typedef half_edge first_argument_type;
+      typedef half_edge second_argument_type;
+      typedef bool result_type;
       inline less_half_edge() : x_(0), justBefore_(0), pack_(0) {}
       inline less_half_edge(Unit *x, int *justBefore, evalAtXforYPack * packIn) : x_(x), justBefore_(justBefore), pack_(packIn) {}
       inline less_half_edge(const less_half_edge& that) : x_(that.x_), justBefore_(that.justBefore_),
@@ -761,11 +767,14 @@ namespace boost { namespace polygon{
     };
 
     //when scanning Vertex45 for polygon formation we need a scanline comparator functor
-    class less_vertex_half_edge : public std::binary_function<vertex_half_edge, vertex_half_edge, bool> {
+    class less_vertex_half_edge {
     private:
       Unit *x_; //x value at which to apply comparison
       int *justBefore_;
     public:
+      typedef vertex_half_edge first_argument_type;
+      typedef vertex_half_edge second_argument_type;
+      typedef bool result_type;
       inline less_vertex_half_edge() : x_(0), justBefore_(0) {}
       inline less_vertex_half_edge(Unit *x, int *justBefore) : x_(x), justBefore_(justBefore) {}
       inline less_vertex_half_edge(const less_vertex_half_edge& that) : x_(that.x_), justBefore_(that.justBefore_) {}
@@ -1195,10 +1204,13 @@ namespace boost { namespace polygon{
 
     typedef std::vector<std::pair<Point, int> > vertex_arbitrary_count;
 
-    class less_half_edge_count : public std::binary_function<vertex_half_edge, vertex_half_edge, bool> {
+    class less_half_edge_count {
     private:
       Point pt_;
     public:
+      typedef vertex_half_edge first_argument_type;
+      typedef vertex_half_edge second_argument_type;
+      typedef bool result_type;
       inline less_half_edge_count() : pt_() {}
       inline less_half_edge_count(Point point) : pt_(point) {}
       inline bool operator () (const std::pair<Point, int>& elm1, const std::pair<Point, int>& elm2) const {
@@ -1213,11 +1225,13 @@ namespace boost { namespace polygon{
 
     typedef std::vector<std::pair<std::pair<std::pair<Point, Point>, int>, active_tail_arbitrary*> > incoming_count;
 
-    class less_incoming_count : public std::binary_function<std::pair<std::pair<std::pair<Point, Point>, int>, active_tail_arbitrary*>,
-                                                            std::pair<std::pair<std::pair<Point, Point>, int>, active_tail_arbitrary*>, bool> {
+    class less_incoming_count {
     private:
       Point pt_;
     public:
+      typedef std::pair<std::pair<std::pair<Point, Point>, int>, active_tail_arbitrary*> first_argument_type;
+      typedef std::pair<std::pair<std::pair<Point, Point>, int>, active_tail_arbitrary*> second_argument_type;
+      typedef bool result_type;
       inline less_incoming_count() : pt_() {}
       inline less_incoming_count(Point point) : pt_(point) {}
       inline bool operator () (const std::pair<std::pair<std::pair<Point, Point>, int>, active_tail_arbitrary*>& elm1,

--- a/include/boost/polygon/detail/scan_arbitrary.hpp
+++ b/include/boost/polygon/detail/scan_arbitrary.hpp
@@ -316,8 +316,11 @@ namespace boost { namespace polygon{
       return true;
     }
 
-    class less_point_down_slope : public std::binary_function<Point, Point, bool> {
+    class less_point_down_slope {
     public:
+      typedef Point first_argument_type;
+      typedef Point second_argument_type;
+      typedef bool result_type;
       inline less_point_down_slope() {}
       inline bool operator () (const Point& pt1, const Point& pt2) const {
         if(pt1.get(HORIZONTAL) < pt2.get(HORIZONTAL)) return true;

--- a/include/boost/polygon/polygon_traits.hpp
+++ b/include/boost/polygon/polygon_traits.hpp
@@ -1183,8 +1183,11 @@ namespace boost { namespace polygon{
     typedef point_data<Unit> Point;
     typedef std::pair<Point, Point> half_edge;
 
-    class less_point : public std::binary_function<Point, Point, bool> {
+    class less_point {
     public:
+      typedef Point first_argument_type;
+      typedef Point second_argument_type;
+      typedef bool result_type;
       inline less_point() {}
       inline bool operator () (const Point& pt1, const Point& pt2) const {
         if(pt1.get(HORIZONTAL) < pt2.get(HORIZONTAL)) return true;


### PR DESCRIPTION
Signed-off-by: Daniela Engert <dani@ngrt.de>