### PR TITLE
Fix polygon_traits.hpp and iterator_geometry_to_set.hpp for compatibility with C++17

### DIFF
--- a/include/boost/polygon/detail/iterator_geometry_to_set.hpp
+++ b/include/boost/polygon/detail/iterator_geometry_to_set.hpp
@@ -100,7 +100,7 @@ public:
     itrb = begin_points(polygon);
     itre = end_points(polygon);
     use_wrap = false;
-    if(itrb == itre || dir == HIGH || size(polygon) < 4) {
+    if(itrb == itre || dir == HIGH || ::boost::polygon::size(polygon) < 4) {
       polygon_index = -1;
     } else {
       direction_1d wdir = w;

--- a/include/boost/polygon/polygon_traits.hpp
+++ b/include/boost/polygon/polygon_traits.hpp
@@ -583,7 +583,7 @@ namespace boost { namespace polygon{
                        polygon_type>::type &
   convolve(polygon_type& polygon, const point_type& point) {
     std::vector<typename polygon_90_traits<polygon_type>::coordinate_type> coords;
-    coords.reserve(size(polygon));
+    coords.reserve(::boost::polygon::size(polygon));
     bool pingpong = true;
     for(typename polygon_90_traits<polygon_type>::compact_iterator_type iter = begin_compact(polygon);
         iter != end_compact(polygon); ++iter) {
@@ -603,7 +603,7 @@ namespace boost { namespace polygon{
                        polygon_type>::type &
   convolve(polygon_type& polygon, const point_type& point) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -655,7 +655,7 @@ namespace boost { namespace polygon{
   typename enable_if< typename is_any_mutable_polygon_without_holes_type<polygon_type>::type, polygon_type>::type &
   transform(polygon_type& polygon, const transform_type& tr) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -689,7 +689,7 @@ namespace boost { namespace polygon{
   typename enable_if< typename is_any_mutable_polygon_without_holes_type<polygon_type>::type, polygon_type>::type &
   scale_up(polygon_type& polygon, typename coordinate_traits<typename polygon_traits<polygon_type>::coordinate_type>::unsigned_area_type factor) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -728,7 +728,7 @@ namespace boost { namespace polygon{
     polygon_type>::type &
   scale_down(polygon_type& polygon, typename coordinate_traits<typename polygon_traits<polygon_type>::coordinate_type>::unsigned_area_type factor) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -824,7 +824,7 @@ namespace boost { namespace polygon{
   typename enable_if< typename is_any_mutable_polygon_without_holes_type<polygon_type>::type, polygon_type>::type &
   snap_to_45(polygon_type& polygon) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -863,7 +863,7 @@ namespace boost { namespace polygon{
     polygon_type>::type &
   scale_down(polygon_type& polygon, typename coordinate_traits<typename polygon_traits<polygon_type>::coordinate_type>::unsigned_area_type factor) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -903,7 +903,7 @@ namespace boost { namespace polygon{
     polygon_type>::type &
   scale(polygon_type& polygon, double factor) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);
@@ -924,7 +924,7 @@ namespace boost { namespace polygon{
         typename geometry_domain<typename geometry_concept<polygon_type>::type>::type>::type>::type>::type * = 0
   ) {
     std::vector<typename std::iterator_traits<typename polygon_traits<polygon_type>::iterator_type>::value_type> points;
-    points.reserve(size(polygon));
+    points.reserve(::boost::polygon::size(polygon));
     for(typename polygon_traits<polygon_type>::iterator_type iter = begin_points(polygon);
         iter != end_points(polygon); ++iter) {
       points.push_back(*iter);


### PR DESCRIPTION
C++17 adds std::size() which breaks all sorts of things, including polygon_traits.hpp and iterator_geometry_to_set.hpp. See https://quuxplusone.github.io/blog/2018/06/17/std-size/ for a description of this problem in general and https://lists.boost.org/Archives/boost/2015/04/221694.php for a report on this instance in particular.

The fix is a little ugly but very straightforward: Use fully-qualified calls to size() wherever ambiguities are possible.