### PR TITLE
Fix mistakes in voronoi_diagram.htm

### DIFF
--- a/doc/voronoi_diagram.htm
+++ b/doc/voronoi_diagram.htm
@@ -825,13 +825,13 @@ const coordinate_type&amp; y)</span><span
           </tr>
           <tr>
             <td style="font-family: Courier New,Courier,monospace;">const
-point_type&amp; <span style="font-weight: bold;">x</span>() const </td>
+coordinate_type&amp; <span style="font-weight: bold;">x</span>() const </td>
             <td>Returns the x-coordinate of the point that represents
 the vertex. </td>
           </tr>
           <tr>
             <td style="font-family: Courier New,Courier,monospace;">const
-point_type&amp; <span style="font-weight: bold;">y</span>() const</td>
+coordinate_type&amp; <span style="font-weight: bold;">y</span>() const</td>
             <td>Returns the y-coordinate of the point that represents
 the vertex. </td>
           </tr>
@@ -982,7 +982,7 @@ False otherwise. It is used to unite nearby Voronoi vertices. </td>
  class="docinfo-content"> </colgroup> <tbody valign="top">
           <tr>
             <th class="docinfo-name">Copyright:</th>
-            <td>Copyright © Andrii Sydorchuk 2010-2013.</td>
+            <td>Copyright Â© Andrii Sydorchuk 2010-2013.</td>
           </tr>
           <tr class="field">
             <th class="docinfo-name">License:</th>


### PR DESCRIPTION
Fix signatures of two voronoi vertex methods:
    - `const point_type& x() const` => `const coordinate_type& x() const`
    - `const point_type& y() const` => `const coordinate_type& y() const`