### PR TITLE
Address Clang 10 [-Wdeprecated-copy] warning.

### DIFF
--- a/include/boost/polygon/detail/voronoi_robust_fpt.hpp
+++ b/include/boost/polygon/detail/voronoi_robust_fpt.hpp
@@ -92,6 +92,8 @@ class robust_fpt {
       fpv_(fpv), re_(0.0) {}
   robust_fpt(floating_point_type fpv, relative_error_type error) :
       fpv_(fpv), re_(error) {}
+  robust_fpt(const robust_fpt& that) :
+      fpv_(that.fpv_), re_(that.re_) {}
 
   floating_point_type fpv() const { return fpv_; }
   relative_error_type re() const { return re_; }


### PR DESCRIPTION
("definition of implicit copy constructor for 'robust_fpt<double>' is deprecated
because it has a user-declared copy assignment operator")

----

One of two warnings that I encountered when building with LLVM 10.

The other one is:

```
boost-polygon/polygon_45_set_data.hpp:1662:24: warning: local variable 'str' will be copied despite being thrown by name [-Wreturn-std-move]
        } else { throw str; }
                       ^~~
boost/polygon/polygon_45_set_data.hpp:1662:24: note: call 'std::move' explicitly to avoid copying
        } else { throw str; }
                       ^~~
                       std::move(str)
```
(And again on line 1773.)

However, I omitted that one because I don't know how far back in terms of C++ Standard Boost aims to be compatible with. Probably there is a macro wrapping `std::move`?