### PR TITLE
Fix compilation under Visual Studio 2019 Preview.

### DIFF
--- a/include/boost/polygon/voronoi_builder.hpp
+++ b/include/boost/polygon/voronoi_builder.hpp
@@ -157,12 +157,12 @@ class voronoi_builder {
   typedef std::map< key_type, value_type, node_comparer_type > beach_line_type;
   typedef typename beach_line_type::iterator beach_line_iterator;
   typedef std::pair<circle_event_type, beach_line_iterator> event_type;
-  typedef struct {
+  struct event_comparison_type {
     bool operator()(const event_type& lhs, const event_type& rhs) const {
       return predicate(rhs.first, lhs.first);
     }
     event_comparison_predicate predicate;
-  } event_comparison_type;
+  };
   typedef detail::ordered_queue<event_type, event_comparison_type>
     circle_event_queue_type;
   typedef std::pair<point_type, beach_line_iterator> end_point_type;

--- a/include/boost/polygon/voronoi_diagram.hpp
+++ b/include/boost/polygon/voronoi_diagram.hpp
@@ -263,7 +263,7 @@ struct voronoi_diagram_traits {
   typedef voronoi_cell<coordinate_type> cell_type;
   typedef voronoi_vertex<coordinate_type> vertex_type;
   typedef voronoi_edge<coordinate_type> edge_type;
-  typedef class {
+  class vertex_equality_predicate_type {
    public:
     enum { ULPS = 128 };
     bool operator()(const vertex_type& v1, const vertex_type& v2) const {
@@ -274,7 +274,7 @@ struct voronoi_diagram_traits {
     }
    private:
     typename detail::ulp_comparison<T> ulp_cmp;
-  } vertex_equality_predicate_type;
+  };
 };
 
 // Voronoi output data structure.


### PR DESCRIPTION
(Version 16.6.0 Preview 2.1, MSVC 14.26.28720)

Apparently, it considers C++20 (n4835) 9.2.3 [dcl.typedef] #10 even
though that paragraph does not appear in the C++17 Standard (draft).

----

This is an odd one. I am compiling as C++17, so as far as I can see it should not trigger. It seems that MSVC chooses to implement the restriction of the mentioned paragraph in a wider scope than just C++20.

As far as I can see, source compatibility should not be affected since the two unnamed classes are only used in private contexts. However:

**CAUTION**: I don't fully know the implications on binary compatibility. (Just, presumably, that this change may break ABI if typedef'd unnamed classes are mangled differently than if you give the class the name directly.)