### PR TITLE
Voronoi multi-precision using 64bit limbs on a 64bit compiler, GMP integration

### DIFF
--- a/include/boost/polygon/detail/voronoi_robust_fpt.hpp
+++ b/include/boost/polygon/detail/voronoi_robust_fpt.hpp
@@ -201,6 +201,12 @@ class robust_fpt {
     return robust_fpt(fpv, re);
   }
 
+  robust_fpt sqr() const {
+    floating_point_type fpv = this->fpv_ * this->fpv_;
+    relative_error_type re = this->re_ * 2 + ROUNDING_ERROR;
+    return robust_fpt(fpv, re);
+  }
+
   robust_fpt sqrt() const {
     return robust_fpt(get_sqrt(fpv_),
                       re_ * static_cast<relative_error_type>(0.5) +
@@ -211,6 +217,11 @@ class robust_fpt {
   floating_point_type fpv_;
   relative_error_type re_;
 };
+
+template <typename T>
+robust_fpt<T> sqr(const robust_fpt<T>& that) {
+  return that.sqr();
+}
 
 template <typename T>
 robust_fpt<T> get_sqrt(const robust_fpt<T>& that) {
@@ -451,7 +462,7 @@ class robust_sqrt_expr {
     if ((!is_neg(a) && !is_neg(b)) ||
         (!is_pos(a) && !is_pos(b)))
       return a + b;
-    return convert(A[0] * A[0] * B[0] - A[1] * A[1] * B[1]) / (a - b);
+    return convert(A[0].sqr() * B[0] - A[1].sqr() * B[1]) / (a - b);
   }
 
   // Evaluates expression (re = 16 EPS):
@@ -462,7 +473,7 @@ class robust_sqrt_expr {
     if ((!is_neg(a) && !is_neg(b)) ||
         (!is_pos(a) && !is_pos(b)))
       return a + b;
-    tA[3] = A[0] * A[0] * B[0] + A[1] * A[1] * B[1] - A[2] * A[2] * B[2];
+    tA[3] = A[0].sqr() * B[0] + A[1].sqr() * B[1] - A[2].sqr() * B[2];
     tB[3] = 1;
     tA[4] = A[0] * A[1] * 2;
     tB[4] = B[0] * B[1];
@@ -479,8 +490,8 @@ class robust_sqrt_expr {
     if ((!is_neg(a) && !is_neg(b)) ||
         (!is_pos(a) && !is_pos(b)))
       return a + b;
-    tA[0] = A[0] * A[0] * B[0] + A[1] * A[1] * B[1] -
-            A[2] * A[2] * B[2] - A[3] * A[3] * B[3];
+    tA[0] = A[0].sqr() * B[0] + A[1].sqr() * B[1] -
+            A[2].sqr() * B[2] - A[3].sqr() * B[3];
     tB[0] = 1;
     tA[1] = A[0] * A[1] * 2;
     tB[1] = B[0] * B[1];


### PR DESCRIPTION
1) On a 64bit compiler, 64bit int is used as a base for the multi-precision int. This makes the Voronoi about 25% faster than the original code.
2) If available, GMP hand crafted vectorized fixed point operators are used. This makes the Voronoi around 50% faster than the original code.

A sqr() operator was introduced instead of x * x, as the sqr operator may be optimized by GMP better than mul.

The unit tests seem to pass all right. I was not quite sure about voronoi_ctype_traits
```
#ifdef BOOST_VORONOI_64_T
  // using uint64 
  typedef extended_int<33> big_int_type;
#else
  // using uint32
  typedef extended_int<64> big_int_type;
#endif 
```

I am using 33 limbs on a 64bit compiler instead of 32. The extended_int multiplication, add and subtract operators drop the top most zero, which leaves space for one limb. With 32bit limbs, the top most 32bit limb is released, while with the same operands the top most 64bit limb would possibly not be zero, therefore it would not be released. Therefore I increased the number of 64bit limbs to 33. Maybe @asydorchuk will consider this one extra limb unnecessary?
