### PR TITLE
Fix default in direction_3d ctor comment

### DIFF
--- a/doc/gtl_isotropy.htm
+++ b/doc/gtl_isotropy.htm
@@ -470,7 +470,7 @@ DOWN = 4, UP = 5 };</font></p>
           <tr>
             <td width="586"><font face="Courier New"><b>direction_3d</b>(direction_2d_enum
 val = WEST)</font></td>
-            <td>Constructor defaults to LOW. </td>
+            <td>Constructor defaults to WEST. </td>
           </tr>
           <tr>
             <td width="586"><b><font face="Courier New">direction_3d</font></b><font
@@ -544,7 +544,7 @@ one if negative direction.</td>
  class="docinfo-content" /> </colgroup> <tbody valign="top">
           <tr>
             <th class="docinfo-name">Copyright:</th>
-            <td>Copyright © Intel Corporation 2008-2010.</td>
+            <td>Copyright Â© Intel Corporation 2008-2010.</td>
           </tr>
           <tr class="field">
             <th class="docinfo-name">License:</th>


### PR DESCRIPTION
Clearly these are inconsistent:  WEST vs LOW

direction_3d(direction_2d_enum val = WEST)	Constructor defaults to LOW.