### PR TITLE
Added missing explicit type casts

### DIFF
--- a/include/boost/polygon/detail/polygon_arbitrary_formation.hpp
+++ b/include/boost/polygon/detail/polygon_arbitrary_formation.hpp
@@ -211,8 +211,8 @@ namespace boost { namespace polygon{
       if(pt.y() == other_pt.y())
         return (high_precision)pt.y();
       evalAtXforYxIn = (high_precision)xIn;
-      evalAtXforYx1 = pt.get(HORIZONTAL);
-      evalAtXforYy1 = pt.get(VERTICAL);
+      evalAtXforYx1 = (high_precision)pt.get(HORIZONTAL);
+      evalAtXforYy1 = (high_precision)pt.get(VERTICAL);
       evalAtXforYdx1 = evalAtXforYxIn - evalAtXforYx1;
       evalAtXforY0 = high_precision(0);
       if(evalAtXforYdx1 == evalAtXforY0) return evalAtXforYret = evalAtXforYy1;
@@ -239,8 +239,8 @@ namespace boost { namespace polygon{
           return evalAtXforYret;
         }
         evalAtXforYxIn = (high_precision)xIn;
-        evalAtXforYx1 = pt.get(HORIZONTAL);
-        evalAtXforYy1 = pt.get(VERTICAL);
+        evalAtXforYx1 = (high_precision)pt.get(HORIZONTAL);
+        evalAtXforYy1 = (high_precision)pt.get(VERTICAL);
         evalAtXforYdx1 = evalAtXforYxIn - evalAtXforYx1;
         evalAtXforY0 = high_precision(0);
         if(evalAtXforYdx1 == evalAtXforY0) return evalAtXforYret = evalAtXforYy1;


### PR DESCRIPTION
Currently, the "coordinate_type" must be implicitly convertible to the "high_precision_type" type, because some explicit type casts are missing. With this change, that's no longer the case.
This is very valuable for a custom "coordinate_type".