### PR TITLE
[voronoi] Avoiding lossy circle event position calculation...

### DIFF
--- a/include/boost/polygon/detail/voronoi_predicates.hpp
+++ b/include/boost/polygon/detail/voronoi_predicates.hpp
@@ -1136,6 +1136,14 @@ class voronoi_predicates {
              const site_type& site3,
              int point_index,
              circle_type& c_event) {
+      if (((site1.point0() == site2.point0()) || (site1.point0() == site2.point1())) &&
+          ((site1.point0() == site3.point0()) || (site1.point0() == site3.point1()))) {
+          
+        // we alreay know the exact location of the event, no need to re-calculate it
+        c_event = circle_type(to_fpt(site1.point0().x()), to_fpt(site1.point0().y()),
+                              to_fpt(site1.point0().x()));
+        return;
+      }
       const point_type& segm_start1 = site2.point1();
       const point_type& segm_end1 = site2.point0();
       const point_type& segm_start2 = site3.point0();


### PR DESCRIPTION
 ...when exact position is already known.

It seems like when: 
point_index==1 the c_event ~is~ may be at site1.point0 == site2.point0 == site3.point1
point_index==2 the c_event ~is~ may be at site1.point0 == site2.point1 == site3.point0

But I'm not confident that's always the case. 

This could also be an opportunity to flag the circle event as a 'site-vertex'. 
i.e. a circle event where the position coincides with a site event. 

Edit: forgot to mention that this will only be true for connected segments, aka polylines. If the input data only consist of disconnected segments the `(site1.point0() == site2.point0()) || ....` test will always return false.
