### PR TITLE
Mark operators const

### DIFF
--- a/include/boost/polygon/detail/polygon_arbitrary_formation.hpp
+++ b/include/boost/polygon/detail/polygon_arbitrary_formation.hpp
@@ -2175,8 +2175,8 @@ namespace boost { namespace polygon{
         itr_ = that.itr_;
         return *this;
       }
-      inline bool operator==(const iterator_holes_type& that) { return itr_ == that.itr_; }
-      inline bool operator!=(const iterator_holes_type& that) { return itr_ != that.itr_; }
+      inline bool operator==(const iterator_holes_type& that) const { return itr_ == that.itr_; }
+      inline bool operator!=(const iterator_holes_type& that) const { return itr_ != that.itr_; }
       inline iterator_holes_type& operator++() {
         ++itr_;
         return *this;


### PR DESCRIPTION
These operators missing the `const` keyword made them incorrect code in C++20:

Let `t.cpp` be the following file:

```cpp
#include <polygon.hpp>
using T = boost::polygon::poly_line_arbitrary_polygon_data<int>::iterator_holes_type;                                                                                         
bool f() { return T{} != T{}; }         
```

Then with `clang-13`:

```sh
% clang++ -std=c++20 -I polygon/include/boost/polygon -c t.cpp
t.cpp:6:23: warning: ISO C++20 considers use of overloaded operator '!=' (with operand types 'T' (aka 'boost::polygon::poly_line_arbitrary_polygon_data<int>::iterator_holes_type') and 'T') to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Wambiguous-reversed-operator]
bool f() { return T{} != T{}; }
                  ~~~ ^  ~~~
polygon/include/boost/polygon/detail/polygon_arbitrary_formation.hpp:2179:19: note: candidate function with non-reversed arguments
      inline bool operator!=(const iterator_holes_type& that) { return itr_ != that.itr_; }
                  ^
polygon/include/boost/polygon/detail/polygon_arbitrary_formation.hpp:2178:19: note: ambiguous candidate function with reversed arguments
      inline bool operator==(const iterator_holes_type& that) { return itr_ == that.itr_; }
                  ^
1 warning generated.
```

Making the operators `const` resolves this issue.