### PR TITLE
Add move in voronoi_diagram with C++11

### DIFF
--- a/include/boost/polygon/voronoi_diagram.hpp
+++ b/include/boost/polygon/voronoi_diagram.hpp
@@ -298,6 +298,11 @@ class voronoi_diagram {
 
   voronoi_diagram() {}
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+  voronoi_diagram(voronoi_diagram&&) = default;
+  voronoi_diagram& operator=(voronoi_diagram&&) = default;
+#endif
+
   void clear() {
     cells_.clear();
     vertices_.clear();


### PR DESCRIPTION
Add default move constructor and assignment operator if neither BOOST_NO_CXX11_RVALUE_REFERENCES nor BOOST_NO_CXX11_DEFAULTED_FUNCTIONS are defined.

Copying of voronoi_diagram is disabled because elements hold pointers which would be invalid after copying. But this would not be the case after move (allocators used by vectors doesn't change).