### PR TITLE
Remove variable ops that is never read from.

### DIFF
--- a/include/boost/polygon/detail/polygon_formation.hpp
+++ b/include/boost/polygon/detail/polygon_formation.hpp
@@ -387,9 +387,7 @@ namespace polygon_formation {
         size_t count = 0;
         End dir = startEnd_;
         PolyLine<Unit> const * currLine = pLine_;
-        size_t ops = 0;
         while(currLine != pLineEnd_){
-           ops++;
            count += currLine->numSegments();
            currLine = currLine->next(dir == HEAD ? TAIL : HEAD);
            dir = currLine->endConnectivity(dir == HEAD ? TAIL : HEAD);


### PR DESCRIPTION
This removes an unused variable to fix a warning with "-Wunused-but-set-variable" when compiling with Clang.