### PR TITLE
Fix polygon_90_set_data::interact

### DIFF
--- a/include/boost/polygon/polygon_90_set_data.hpp
+++ b/include/boost/polygon/polygon_90_set_data.hpp
@@ -788,6 +788,7 @@ namespace boost { namespace polygon{
 
     inline polygon_90_set_data& interact(const polygon_90_set_data& that) {
       typedef coordinate_type Unit;
+      if(dirty_) clean();
       if(that.dirty_) that.clean();
       typename touch_90_operation<Unit>::TouchSetData tsd;
       touch_90_operation<Unit>::populateTouchSetData(tsd, that.data_, 0);


### PR DESCRIPTION
This method was producing incorrect results if the left hand object was not already normalized (i.e. dirty)