### PR TITLE
Annotate facade header with IWYU export annotation

### DIFF
--- a/include/boost/polygon/polygon.hpp
+++ b/include/boost/polygon/polygon.hpp
@@ -9,6 +9,8 @@
 #define BOOST_POLYGON_POLYGON_HPP
 #define BOOST_POLYGON_VERSION 014401
 
+// IWYU pragma: begin_exports
+
 #include "isotropy.hpp"
 
 //point
@@ -88,5 +90,7 @@
 #include "polygon_set_concept.hpp"
 
 #include "segment_utils.hpp"
+
+// IWYU pragma: end_exports
 
 #endif


### PR DESCRIPTION
Without that annotation, tools such as `clang-tidy` or the `clangd` language server (as well as many other tools) will complain about headers not directly providing a symbol if users include `polygon.hpp`; With this annotation, they know.

Documentation IWYU
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports

Documentation llvm include cleaner/clang-tidy/clangd https://clangd.llvm.org/design/include-cleaner#iwyu-pragmas