### PR TITLE
Fix incorrect extended_int chunk size in Voronoi Builder documentation

### DIFF
--- a/doc/voronoi_builder.htm
+++ b/doc/voronoi_builder.htm
@@ -199,7 +199,7 @@ struct voronoi_ctype_traits&lt;int32&gt; {<br>
 &nbsp;&nbsp;&nbsp; typedef int32 int_type;<br>
 &nbsp;&nbsp;&nbsp; typedef int64 int_x2_type;<br>
 &nbsp;&nbsp;&nbsp; typedef uint64 uint_x2_type;<br>
-&nbsp;&nbsp;&nbsp; typedef extended_int&lt;128&gt; big_int_type;<br>
+&nbsp;&nbsp;&nbsp; typedef extended_int&lt;64&gt; big_int_type;<br>
 &nbsp;&nbsp;&nbsp; typedef fpt64 fpt_type;<br>
 &nbsp;&nbsp;&nbsp; typedef extended_exponent_fpt&lt;fpt_type&gt;
 efpt_type;<br>
@@ -314,7 +314,7 @@ tutorial</a>.</li>
         <colgroup> <col class="docinfo-name"><col class="docinfo-content"> </colgroup> <tbody valign="top">
           <tr>
             <th class="docinfo-name">Copyright:</th>
-            <td>Copyright © Andrii Sydorchuk 2010-2013.</td>
+            <td>Copyright Â© Andrii Sydorchuk 2010-2013.</td>
           </tr>
           <tr class="field">
             <th class="docinfo-name">License:</th>


### PR DESCRIPTION
In the example code for `voronoi_builder_traits<int32>`, `big_int_type` is incorrectly typed as `extended_int<128>`. It should be `extended_int<64>`. 

Source: https://github.com/boostorg/polygon/blob/ddb9c8adadbbb539fe52cb7f8ee0a446ba5ead04/include/boost/polygon/detail/voronoi_ctypes.hpp#L632